### PR TITLE
Simplify log filename

### DIFF
--- a/MailLoggerPlugin.inc.php
+++ b/MailLoggerPlugin.inc.php
@@ -50,7 +50,7 @@ class MailLoggerPlugin extends GenericPlugin {
 		if (!file_exists($dir)) {
 			mkdir($dir);
 		}
-		$fn = date('Ymdhis') . '-' . microtime();
+		$fn = date('Ymdhis') . '-' . explode(' ', microtime())[0];
 		file_put_contents("$dir/$fn", print_r($mail->_data, true));
 	}
 }


### PR DESCRIPTION
`microtime()` gives a space-separated string, the second component of which is seconds since epoch.  This is already represented in `date('Ymdhis')`, so there is no added uniqueness and is added ugliness/pain of the space in the filename.